### PR TITLE
Remove Python 2.7 support from appveyor as well

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,9 +10,6 @@ environment:
     secure: yz5KKf5dQbaqyqnlq32LSt5BLNK10eqavFqOzTixaikBeNmG3G/fX870+XR0Sih/
 
   matrix:
-    - CONFIG: win_python2.7
-      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
-
     - CONFIG: win_python3.6
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 


### PR DESCRIPTION
This is to remove Python 2.7 support from Appveyor integration as well. This should make #1 passing.