### PR TITLE
reverting to original feedstock rendering

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,12 +13,10 @@ jobs:
       linux_python3.6:
         CONFIG: linux_python3.6
         UPLOAD_PACKAGES: True
-        UPLOAD_ON_BRANCH: master
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_python3.7:
         CONFIG: linux_python3.7
         UPLOAD_PACKAGES: True
-        UPLOAD_ON_BRANCH: master
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
@@ -31,11 +29,6 @@ jobs:
 
   - script: |
         export CI=azure
-        if [ "$(Build.SourceBranch)" == "refs/heads/$UPLOAD_ON_BRANCH" -a $UPLOAD_PACKAGES == "True" ]; then
-            export UPLOAD_PACKAGES=True
-        else
-            export UPLOAD_PACKAGES=False
-        fi
         .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -13,11 +13,9 @@ jobs:
       osx_python3.6:
         CONFIG: osx_python3.6
         UPLOAD_PACKAGES: True
-        UPLOAD_ON_BRANCH: master
       osx_python3.7:
         CONFIG: osx_python3.7
         UPLOAD_PACKAGES: True
-        UPLOAD_ON_BRANCH: master
 
   steps:
   # TODO: Fast finish on azure pipelines?
@@ -77,4 +75,3 @@ jobs:
     displayName: Upload recipe
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: and(eq(variables['UPLOAD_PACKAGES'], 'True'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['UPLOAD_ON_BRANCH'])))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,12 +14,10 @@ jobs:
         CONFIG: win_python3.6
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-        UPLOAD_ON_BRANCH: master
       win_python3.7:
         CONFIG: win_python3.7
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-        UPLOAD_ON_BRANCH: master
   steps:
     # TODO: Fast finish on azure pipelines?
     - script: |
@@ -104,4 +102,3 @@ jobs:
         upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-      condition: and(eq(variables['UPLOAD_PACKAGES'], 'True'), eq(variables['Build.SourceBranch'], format('refs/heads/{0}', variables['UPLOAD_ON_BRANCH'])))

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -20,4 +20,3 @@ provider:
   linux: azure
   osx: azure
   win: azure
-upload_on_branch: master

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_rev: v{{ version }}
 
 build:
-  number: 8
+  number: 9
   script: python setup.py install --single-version-externally-managed --record=record.txt
   skip: True  # [py<36]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 9
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   skip: True  # [py<36]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
 
 build:
   number: 9
-   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   skip: True  # [py<36]
 
 requirements:
   host:
     - python
-    - setuptools
+    - pip
   run:
     - jsonschema >=3.0.0
     - numpy


### PR DESCRIPTION
- Build No. 9
- Restoring feedstock files to match templates from conda smithy repo
- Showing that when 'upload_on_branch' is not defined in conda-forge.yml, files follow original templates
- Example for PR