### PR TITLE
Use of upload_on_branch variable

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_rev: v{{ version }}
 
 build:
-  number: 9
+  number: 10
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   skip: True  # [py<36]
 


### PR DESCRIPTION
- Showing how changes commited on branches other than master from the same repo won't trigger uploads to anaconda.org
- Example for PR